### PR TITLE
ngSwipe add support of pointer api

### DIFF
--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -86,6 +86,10 @@
       y = y || 0;
       evnt.initMouseEvent(eventType, true, true, window, 0, x, y, x, y, pressed('ctrl'),
           pressed('alt'), pressed('shift'), pressed('meta'), 0, relatedTarget);
+
+      if (eventData && eventData.pointerType) {
+        evnt.pointerType = eventData.pointerType;
+      }
     }
 
     /* we're unable to change the timeStamp value directly so this

--- a/test/ngTouch/swipeSpec.js
+++ b/test/ngTouch/swipeSpec.js
@@ -23,9 +23,11 @@ describe('$swipe', function() {
 
   describe('pointerTypes', function() {
     var usedEvents;
-    var MOUSE_EVENTS = ['mousedown','mousemove','mouseup'].sort();
-    var TOUCH_EVENTS = ['touchcancel','touchend','touchmove','touchstart'].sort();
+    var POINTER_EVENTS = ['pointerdown', 'pointerup', 'pointermove', 'pointercancel'];
+    var TOUCH_EVENTS = ['touchcancel','touchend','touchmove','touchstart'].concat(POINTER_EVENTS).sort();
+    var MOUSE_EVENTS = ['mousedown','mousemove','mouseup'];
     var ALL_EVENTS = MOUSE_EVENTS.concat(TOUCH_EVENTS).sort();
+    MOUSE_EVENTS = MOUSE_EVENTS.concat(POINTER_EVENTS).sort();
 
     beforeEach(function() {
       usedEvents = [];
@@ -59,6 +61,7 @@ describe('$swipe', function() {
   });
 
   swipeTests('touch', /* restrictBrowers */ true, 'touchstart', 'touchmove', 'touchend');
+  swipeTests('pointer', /* restrictBrowers */ false, 'pointerdown', 'pointermove', 'pointerup');
   swipeTests('mouse', /* restrictBrowers */ false, 'mousedown',  'mousemove', 'mouseup');
 
   // Wrapper to abstract over using touch events or mouse events.
@@ -374,4 +377,62 @@ describe('$swipe', function() {
     });
   }
 
+  describe('ignoring mouse events when using pointer API for touch only event', function() {
+    it('should not trigger start when event is from mouse', inject(function($swipe) {
+      $swipe.bind(element, events, ['touch']);
+
+      expect(events.start).not.toHaveBeenCalled();
+      expect(events.move).not.toHaveBeenCalled();
+      expect(events.cancel).not.toHaveBeenCalled();
+      expect(events.end).not.toHaveBeenCalled();
+
+      browserTrigger(element, 'pointerdown',{
+        keys: [],
+        pointerType: 'mouse',
+        x: 100,
+        y: 20
+      });
+
+      expect(events.start).not.toHaveBeenCalled();
+
+      expect(events.move).not.toHaveBeenCalled();
+      expect(events.cancel).not.toHaveBeenCalled();
+      expect(events.end).not.toHaveBeenCalled();
+    }));
+  });
+
+  it('should not trigger move when event is from mouse', inject(function($swipe) {
+    $swipe.bind(element, events, ['touch']);
+
+    expect(events.start).not.toHaveBeenCalled();
+    expect(events.move).not.toHaveBeenCalled();
+    expect(events.cancel).not.toHaveBeenCalled();
+    expect(events.end).not.toHaveBeenCalled();
+
+    browserTrigger(element, 'pointerdown',{
+      keys: [],
+      pointerType: 'touch',
+      x: 100,
+      y: 20
+    });
+
+    expect(events.start).toHaveBeenCalled();
+
+    expect(events.move).not.toHaveBeenCalled();
+    expect(events.cancel).not.toHaveBeenCalled();
+    expect(events.end).not.toHaveBeenCalled();
+
+    browserTrigger(element, 'pointermove',{
+      keys: [],
+      pointerType: 'mouse',
+      x: 140,
+      y: 20
+    });
+
+    expect(events.start).toHaveBeenCalled();
+    expect(events.move).not.toHaveBeenCalled();
+
+    expect(events.cancel).not.toHaveBeenCalled();
+    expect(events.end).not.toHaveBeenCalled();
+  }));
 });


### PR DESCRIPTION
ngSwipe did not work on IE11 because IE11 does not provide touch API but pointer API. 
This commit add the support of pointer API to ngSwipe to make it compatible with IE11 and fix the issue 14061.
